### PR TITLE
Download feature tweak.

### DIFF
--- a/background.js
+++ b/background.js
@@ -81,7 +81,6 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
     case "twitter-img-download":
       var downloading = browser.downloads.download({
         url: lastOrigUrl,
-        saveAs: false,
         filename: fileName // Optional
       });
       downloading.then(function(id) {/* console.log('triggering download: ', lastOrigUrl, fileName, id);*/}, onError);


### PR DESCRIPTION
   - Instead of forcing 'saveAs: false', don't include it to make firefox use its default behaviour instead. As described in:
   https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/downloads/download

I do believe this would solve my problems described in:
https://github.com/euank/twitter-image-helper/issues/6